### PR TITLE
Rails5 compatibility

### DIFF
--- a/lib/telegram/bot/updates_controller/instrumentation.rb
+++ b/lib/telegram/bot/updates_controller/instrumentation.rb
@@ -6,7 +6,7 @@ module Telegram
       module Instrumentation
         class << self
           def prepended(base)
-            base.config_accessor :logger
+            base.send :config_accessor, :logger
             base.extend ClassMethods
           end
 

--- a/telegram-bot.gemspec
+++ b/telegram-bot.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.0'
 
-  spec.add_dependency 'activesupport', '~> 4.0'
-  spec.add_dependency 'actionpack', '~> 4.0'
+  spec.add_dependency 'activesupport', '>= 4.0', '< 5.1'
+  spec.add_dependency 'actionpack', '>= 4.0', '< 5.1'
   spec.add_dependency 'httpclient', '~> 2.7'
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
- [x] update gemspec
- [x] `ActiveSupport::Configurable.config_accessor` is now [private](https://github.com/rails/rails/commit/c2bfe6cbc8cab9caeab418472a1e12a3ed3e75e2#diff-470773f9c7fa0f2797b55795736dff0dR125)
- [x] use `Rails.application.reloader.reload!` instead of `ActionDispatch::Reloader.prepare!` + `ActionDispatch::Reloader.cleanup!`
- [ ] backwards compatibility