### PR TITLE
fix reply_with and reply_to_message_id

### DIFF
--- a/lib/telegram/bot/updates_controller/reply_helpers.rb
+++ b/lib/telegram/bot/updates_controller/reply_helpers.rb
@@ -14,7 +14,7 @@ module Telegram
           payload = self.payload
           params = params.merge(
             chat_id: (chat && chat['id'] or raise 'Can not reply_with when chat is not present'),
-            reply_to_message: payload && payload['message_id'],
+            reply_to_message_id: payload && payload['message_id'],
           )
           bot.public_send(method, params)
         end

--- a/spec/telegram/bot/updates_controller/reply_helpers_spec.rb
+++ b/spec/telegram/bot/updates_controller/reply_helpers_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Telegram::Bot::UpdatesController do
       expect(controller).to receive(:chat) { chat }
       expect(bot).to receive("send_#{type}").with(params.merge(
         chat_id: chat['id'],
-        reply_to_message: payload[:message_id],
+        reply_to_message_id: payload[:message_id],
       )) { result }
       should eq result
     end
@@ -29,7 +29,7 @@ RSpec.describe Telegram::Bot::UpdatesController do
       it 'sets chat_id & reply_to_message' do
         expect(bot).to receive("send_#{type}").with(params.merge(
           chat_id: chat['id'],
-          reply_to_message: nil,
+          reply_to_message_id: nil,
         )) { result }
         should eq result
       end


### PR DESCRIPTION
[`sendMessage`](https://core.telegram.org/bots/api#sendmessage) accepts `reply_to_message_id` not `reply_to_message` 

However this will be a potentially breaking change for existing gem users