### PR TITLE
get request parameters from ActionDispatch::Request

### DIFF
--- a/lib/telegram/bot/middleware.rb
+++ b/lib/telegram/bot/middleware.rb
@@ -1,3 +1,8 @@
+if ActiveSupport.gem_version >= Gem::Version.new('5.0.0.rc1')
+  require 'active_support/json'
+  require 'active_support/logger'
+  require 'active_support/core_ext/hash/indifferent_access'
+end
 require 'active_support/concern'
 require 'action_dispatch/http/mime_type'
 require 'action_dispatch/middleware/params_parser'
@@ -13,7 +18,11 @@ module Telegram
       end
 
       def call(env)
-        update = env['action_dispatch.request.request_parameters']
+        update = if ActiveSupport.gem_version >= Gem::Version.new('5.0.0.rc1')
+                   ActionDispatch::Request.new(env).request_parameters
+                 else
+                   env['action_dispatch.request.request_parameters']
+                 end
         controller.dispatch(bot, update)
         [200, {}, ['']]
       end

--- a/spec/telegram/bot/middleware_spec.rb
+++ b/spec/telegram/bot/middleware_spec.rb
@@ -1,3 +1,5 @@
+require 'rack/mock'
+
 RSpec.describe Telegram::Bot::Middleware do
   let(:instance) { described_class.new bot, controller }
   let(:bot) { double(:bot) }
@@ -5,12 +7,28 @@ RSpec.describe Telegram::Bot::Middleware do
 
   describe '#call' do
     subject { instance.call(env) }
-    let(:env) { {'action_dispatch.request.request_parameters' => json_body} }
-    let(:json_body) { double(:json_body) }
 
-    it 'calls dispatch on controller' do
-      expect(controller).to receive(:dispatch).with(bot, json_body)
-      subject
+    if ActiveSupport.gem_version >= Gem::Version.new('5.0.0.rc1')
+      let(:env) do
+        Rack::MockRequest.env_for('/',
+                                  method: :post,
+                                  input: '{"valid": "json"}',
+                                  'CONTENT_TYPE' => 'application/json'
+                                 )
+      end
+
+      it 'calls dispatch on controller' do
+        expect(controller).to receive(:dispatch).with(bot, hash_including(valid: 'json'))
+        subject
+      end
+    else
+      let(:json_body) { double(:json_body) }
+      let(:env) { {'action_dispatch.request.request_parameters' => json_body} }
+
+      it 'calls dispatch on controller' do
+        expect(controller).to receive(:dispatch).with(bot, json_body)
+        subject
+      end
     end
 
     it { should eq [200, {}, ['']] }


### PR DESCRIPTION
In Rails 5 request parameters are not eagerly parsed [anymore](https://github.com/rails/rails/commit/91d05082e43008f2617d468fdd6c0de95855fe7f)

This leads to `env['action_dispatch.request.request_parameters']` being empty in `Telegram::Bot::Middleware#call`

I did not change the logic for Rails < 5, though I think new approach will also work for Rails 4

Tested this against both Rails 4 and Rails 5 manually, but I think we should use something like Appraisal  in dev and build matrix in Travis