### PR TITLE
escape_token for nil value

### DIFF
--- a/lib/telegram/bot/routes_helper.rb
+++ b/lib/telegram/bot/routes_helper.rb
@@ -20,6 +20,7 @@ module Telegram
         # Replaces colon with underscore so rails don't treat it as
         # route parameter.
         def escape_token(token)
+          token ||= ""
           token.tr(':', '_')
         end
       end


### PR DESCRIPTION
Fix escaping nil causing "NoMethodError: undefined method `tr' for nil:NilClass".