### PR TITLE
Error "can't dup Fixnum (TypeError)"

### DIFF
--- a/lib/telegram/bot/async.rb
+++ b/lib/telegram/bot/async.rb
@@ -116,7 +116,7 @@ module Telegram
 
       attr_reader :id
 
-      def initialize(*, id: nil, async: nil, **)
+      def initialize(*, id: nil, async: nil, **options)
         @id = id
         self.async = async
         super

--- a/lib/telegram/bot/botan/client_helpers.rb
+++ b/lib/telegram/bot/botan/client_helpers.rb
@@ -5,7 +5,7 @@ module Telegram
       module ClientHelpers
         attr_reader :botan
 
-        def initialize(*, botan: nil, **)
+        def initialize(*, botan: nil, **options)
           super
           @botan = Botan.wrap(botan, id: id) if botan
         end


### PR DESCRIPTION
I got these errors with Ruby 2.2.0:

> /home/frost/.rvm/gems/ruby-2.2.0@mkk/gems/telegram-bot-0.9.0/lib/telegram/bot/botan/client_helpers.rb:9:in `dup': can't dup Fixnum (TypeError)
> from /home/frost/.rvm/gems/ruby-2.2.0@mkk/gems/telegram-bot-0.9.0/lib/telegram/bot/botan/client_helpers.rb:9:in `initialize'

> /home/frost/.rvm/gems/ruby-2.2.0@mkk/gems/telegram-bot-0.9.0/lib/telegram/bot/async.rb:122:in `dup': can't dup Fixnum (TypeError)
> from /home/frost/.rvm/gems/ruby-2.2.0@mkk/gems/telegram-bot-0.9.0/lib/telegram/bot/async.rb:122:in `initialize'

Seems like it is because of [this bug](https://bugs.ruby-lang.org/issues/10659)