### PR TITLE
Update sessions

### DIFF
--- a/lib/telegram/bot/railtie.rb
+++ b/lib/telegram/bot/railtie.rb
@@ -18,7 +18,7 @@ module Telegram
 
         ActiveSupport.on_load('telegram.bot.updates_controller') do
           self.logger = options.logger || Rails.logger
-          self.session_store = options.session_store || Rails.cache
+          self.session_store = options.session_store if options.session_store
         end
       end
 

--- a/lib/telegram/bot/updates_controller/session.rb
+++ b/lib/telegram/bot/updates_controller/session.rb
@@ -8,19 +8,26 @@ module Telegram
       module Session
         extend ActiveSupport::Concern
 
+        module ClassMethods
+          # Builds session with given key and optional store (default to session_store).
+          # This way it's easier to define multiple custom sessions,
+          # ex. one for group chat and one for user.
+          def build_session(key, store = session_store)
+            raise 'session_store is not configured' unless store
+            key ? SessionHash.new(store, key) : NullSessionHash.new
+          end
+        end
+
         def process_action(*)
           super
         ensure
-          session.commit
+          session.commit if @_session
         end
 
         protected
 
         def session
-          @_session ||= begin
-            key = session_key
-            key ? SessionHash.new(self.class.session_store, key) : NullSessionHash.new
-          end
+          @_session ||= self.class.build_session(session_key)
         end
 
         def session_key

--- a/spec/integration/requests/default_bot_spec.rb
+++ b/spec/integration/requests/default_bot_spec.rb
@@ -5,4 +5,9 @@ RSpec.describe DefaultBotController, :telegram_bot, type: :request do
     subject { -> { dispatch_command :start } }
     it { should respond_with_message 'from default' }
   end
+
+  describe '#load_session' do
+    subject { -> { dispatch_command :load_session } }
+    it { should_not raise_error }
+  end
 end

--- a/spec/integration/requests/other_bot_spec.rb
+++ b/spec/integration/requests/other_bot_spec.rb
@@ -6,4 +6,9 @@ RSpec.describe OtherBotController, :telegram_bot, type: :request do
     subject { -> { dispatch_command :start } }
     it { should respond_with_message 'from other' }
   end
+
+  describe '#load_session' do
+    subject { -> { dispatch_command :load_session } }
+    it { should raise_error(/session_store is not configured/) }
+  end
 end

--- a/spec/telegram/bot/updates_controller/session_spec.rb
+++ b/spec/telegram/bot/updates_controller/session_spec.rb
@@ -54,4 +54,45 @@ RSpec.describe Telegram::Bot::UpdatesController::Session do
       end
     end
   end
+
+  describe '.build_session' do
+    subject { controller_class.build_session(key, *args) }
+    let(:key) {}
+    let(:args) { [] }
+    it { expect { subject }.to raise_error(/session_store is not configured/) }
+
+    shared_examples 'NullSessionHash when key is not present' do |store_proc|
+      it { should be_instance_of(described_class::NullSessionHash) }
+
+      context 'and key is present' do
+        let(:key) { :test_key }
+        it 'is valid SessionHash' do
+          expect(subject).to be_instance_of(described_class::SessionHash)
+          expect(subject.id).to eq key
+          expect(subject.instance_variable_get(:@store)).to be(instance_exec(&store_proc))
+        end
+      end
+    end
+
+    context 'when store configured' do
+      before { controller_class.session_store = nil }
+      include_examples 'NullSessionHash when key is not present',
+        -> { controller_class.session_store }
+    end
+
+    context 'when store is given' do
+      let(:args) { [double(:store)] }
+      include_examples 'NullSessionHash when key is not present', -> { args[0] }
+    end
+  end
+
+  describe '.session_store=' do
+    subject { ->(val) { controller_class.session_store = val } }
+    it 'casts to AS::Cache' do
+      expect { subject[:null_store] }.to change(controller_class, :session_store).
+        to(instance_of(ActiveSupport::Cache::NullStore))
+      expect { subject[nil] }.to change(controller_class, :session_store).
+        to(instance_of(ActiveSupport::Cache::MemoryStore))
+    end
+  end
 end


### PR DESCRIPTION
- Make `#session` raise error when store is not configured 
- Don't use Rails.cache as fallback for session_store 
- Allow use different sessions for MessageContext