### PR TITLE
Fix #63

### DIFF
--- a/lib/telegram/bot/config_methods.rb
+++ b/lib/telegram/bot/config_methods.rb
@@ -1,5 +1,5 @@
 require 'active_support/core_ext/hash/keys'
-require 'active_support/core_ext/hash/transform_values'
+require 'active_support/core_ext/hash/transform_values' if RUBY_VERSION < '2.4'
 require 'active_support/core_ext/hash/indifferent_access'
 
 module Telegram


### PR DESCRIPTION
DEPRECATION WARNING: Ruby 2.4+ (required by Rails 6) provides Hash#transform_values natively, so requiring active_support/core_ext/hash/transform_values is no longer necessary. Requiring it will raise LoadError in Rails 6.1.