### PR TITLE
Allow Telegram commands to start with a number

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,13 @@ class Telegram::WebhookController < Telegram::Bot::UpdatesController
     reply_with :photo, photo: File.open('party.jpg')
   end
 
+  # If a comand starts with a number, then you must prefix
+  # it with `on_` because Ruby doesn't allow functions to
+  # start with numbers.
+  def on_1command!(*)
+    respond_with :message, text: 'You sent /1command'
+  end
+
   private
 
   def with_locale(&block)

--- a/lib/telegram/bot/updates_controller/commands.rb
+++ b/lib/telegram/bot/updates_controller/commands.rb
@@ -4,6 +4,7 @@ module Telegram
       #  Support for parsing commands
       module Commands
         CMD_REGEX = %r{\A/([a-z\d_]{,31})(@(\S+))?(\s|$)}i
+        CMD_CONFLICT_REGEX = /^(\d)/
 
         class << self
           # Fetches command from text message. All subsequent words are returned
@@ -22,8 +23,10 @@ module Telegram
 
         # Override it to filter or transform commands.
         # Default implementation is to downcase and add `!` suffix.
+        # If the command conflict with the way that Ruby names methods (i.e. starts with
+        # a number) then it will prepend 'on_'
         def action_for_command(cmd)
-          "#{cmd.downcase}!"
+          cmd.match(CMD_CONFLICT_REGEX) ? "on_#{cmd.downcase}!" : "#{cmd.downcase}!"
         end
 
         # If payload is a message with command, then returned action is an

--- a/spec/telegram/bot/updates_controller/commands_spec.rb
+++ b/spec/telegram/bot/updates_controller/commands_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Telegram::Bot::UpdatesController::Commands do
 
     it 'prepends on_ to commands that start with a number' do
       assert_subject '1test', 'on_1test!'
+      assert_subject '123test', 'on_123test!'
     end
   end
 

--- a/spec/telegram/bot/updates_controller/commands_spec.rb
+++ b/spec/telegram/bot/updates_controller/commands_spec.rb
@@ -7,10 +7,14 @@ RSpec.describe Telegram::Bot::UpdatesController::Commands do
       expect(subject.call input).to eq expected
     end
 
-    it 'bypasses and downcases not conflictint commands' do
+    it 'bypasses and downcases not conflicting commands' do
       assert_subject 'test', 'test!'
       assert_subject 'TeSt', 'test!'
       assert_subject '_Te1St', '_te1st!'
+    end
+
+    it 'prepends on_ to commands that start with a number' do
+      assert_subject '1test', 'on_1test!'
     end
   end
 


### PR DESCRIPTION
In release 0.14, commands were changed so that they would call the action corresponding to `#{command}!`. However, this breaks commands that start with a number since Ruby doesn't allow methods to start with a number. So I added back this ability by prepending `on_` to handlers for commands starting with a number. 

I also added tests for this functionality.