### PR TITLE
Fix small README issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ RSpec.describe TelegramWebhooksController, telegram_bot: :rails do
   #   dispatch_command(cmd, *args)
 
   # Available matchers can be found in Telegram::Bot::RSpec::ClientMatchers.
-  it 'shows usage of basic matchers'
+  it 'shows usage of basic matchers' do
     # The most basic one is #make_telegram_request(bot, endpoint, params_matcher)
     expect { dispatch_command(:start) }.
       to make_telegram_request(bot, :sendMessage, hash_including(text: 'msg text'))

--- a/README.md
+++ b/README.md
@@ -476,9 +476,8 @@ RSpec.describe TelegramWebhooksController, telegram_bot: :rails do
 
   # Available matchers can be found in Telegram::Bot::RSpec::ClientMatchers.
   it 'shows usage of basic matchers' do
-    # The most basic one is #make_telegram_request(bot, endpoint, params_matcher)
-    expect { dispatch_command(:start) }.
-      to make_telegram_request(bot, :sendMessage, hash_including(text: 'msg text'))
+    # The most basic one is #make_telegram_request(bot, action)
+    expect { dispatch_command(:start) }.to make_telegram_request(bot, :sendMessage)
 
     # There are some shortcuts for dispatching basic updates and testing responses.
     expect { dispatch_message('Hi') }.to send_telegram_message(bot, /msg regexp/, some: :option)

--- a/README.md
+++ b/README.md
@@ -476,8 +476,10 @@ RSpec.describe TelegramWebhooksController, telegram_bot: :rails do
 
   # Available matchers can be found in Telegram::Bot::RSpec::ClientMatchers.
   it 'shows usage of basic matchers' do
-    # The most basic one is #make_telegram_request(bot, action)
-    expect { dispatch_command(:start) }.to make_telegram_request(bot, :sendMessage)
+    # The most basic one is #make_telegram_request(bot, action).
+    # It works similar to `receive` matcher and supports chaining `.with(args).exactly(n).times`.
+    expect { dispatch_command(:start) }.to make_telegram_request(bot, :sendMessage).
+      with(hash_including(text: 'msg text'))
 
     # There are some shortcuts for dispatching basic updates and testing responses.
     expect { dispatch_message('Hi') }.to send_telegram_message(bot, /msg regexp/, some: :option)


### PR DESCRIPTION
- Adds missing `do` to spec example
- Removes incorrect argument from `make_telegram_request` spec example