### PR TITLE
Add location helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Rails 6.0 support.
 - Update to Bot API 4.4.
+- Add `location` helper
 
 # 0.14.2
 

--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ class Telegram::WebhookController < Telegram::Bot::UpdatesController
   def start!(data = nil, *)
     # do_smth_with(data)
 
-    # There are `chat` & `from` shortcut methods.
-    # For callback queries `chat` if taken from `message` when it's available.
+    # There are `chat` & `from` & `location` shortcut methods.
+    # For callback queries `chat` is taken from `message` when it's available.
     response = from ? "Hello #{from['username']}!" : 'Hi there!'
     # There is `respond_with` helper to set `chat_id` from received message:
     respond_with :message, text: response

--- a/lib/telegram/bot/updates_controller.rb
+++ b/lib/telegram/bot/updates_controller.rb
@@ -117,16 +117,17 @@ module Telegram
       delegate :username, to: :bot, prefix: true, allow_nil: true
 
       # Second argument can be either update object with hash access & string
-      # keys or Hash with `:from` or `:chat` to override this values and assume
-      # that update is nil.
+      # keys or Hash with `:from`, `:chat`, or `location` to override this
+      # values and assume that update is nil.
       def initialize(bot = nil, update = nil)
-        if update.is_a?(Hash) && (update.key?(:from) || update.key?(:chat))
+        if update.is_a?(Hash) &&
+            (update.key?(:from) || update.key?(:chat) || update.key?(:location))
           options = update
           update = nil
         end
         @_update = update
         @_bot = bot
-        @_chat, @_from = options && options.values_at(:chat, :from)
+        @_chat, @_from, @_location = options && options.values_at(:chat, :from, :location)
         @_payload, @_payload_type = self.class.payload_from_update(update)
       end
 
@@ -149,6 +150,12 @@ module Telegram
       # for #initialize.
       def from
         @_from ||= payload && payload['from']
+      end
+
+      # Accessor to `'location'` field of payload. Can be overriden with
+      # `location` option for #initialize.
+      def location
+        @_location ||= payload && payload['location']
       end
 
       # Processes current update.

--- a/spec/telegram/bot/updates_controller_spec.rb
+++ b/spec/telegram/bot/updates_controller_spec.rb
@@ -246,4 +246,21 @@ RSpec.describe Telegram::Bot::UpdatesController do
       it { should eq nil }
     end
   end
+
+  describe '#location' do
+    subject { controller.location }
+    let(:payload_type) { :message }
+    let(:payload) { {location: {'latitude' => 48.833675, 'longitude' => 2.375342}} }
+    it { should eq payload[:location] }
+
+    context 'when payload is not set' do
+      let(:payload) {}
+      it { should eq nil }
+    end
+
+    context 'when payload has no such field' do
+      let(:payload) { {smth: 'other'} }
+      it { should eq nil }
+    end
+  end
 end


### PR DESCRIPTION
Telegram allows users to send a location. This location (latitude,
longitude) is present in the message payload under the `location` key:

```

{
   "update_id":1234,
   "message":{
      "message_id":123,
      "from":{
         "id":1234567,
         "is_bot":false,
         "first_name":"Bob",
         "username":"bob",
         "language_code":"en"
      },
      "chat":{
         "id":1234567,
         "first_name":"Bob",
         "username":"bob",
         "type":"private"
      },
      "date":1580309781,
      "location":{
         "latitude":48.833675,
         "longitude":2.375342
      }
   }
}

```

The `location` helper returns the latitude + longitude hash if present:

```
 location
 #=> { "latitude":48.833675, "longitude":2.375342 }
```