### PR TITLE
Use token hash in routes instead of plain value, support :path option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- Add `:path` option to `telegram_webhook` route helper.
+- __Breaking change!__ Default route is generated using hashed bot token.
+  Please reconfigure webhook after update (`rake telegram:bot:set_webhook`).
+
 # 0.14.4
 
 - Update to Bot API 4.7

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ end
 ### Routes in Rails app
 
 There is `telegram_webhook` helper for rails app to define routes for webhooks.
-It defines routes at `telegram/#{bot.token}` and connects bots with controller.
+It defines routes at `telegram/#{hash_of(bot.token)}` and connects bots with controller.
 
 ```ruby
 # Most off apps would require


### PR DESCRIPTION
Fixes #127

Request url can be logged on proxies or even be sent to errors collector, which can be third-party website. So it's less secure to use plain token in the url.

This PR introduces breaking change to provide better security. Webhook url will be changed after update, so it must be reconfigured.