### PR TITLE
fix: make I18n.translation options ruby 3.0 compatible

### DIFF
--- a/lib/telegram/bot/updates_controller/translation.rb
+++ b/lib/telegram/bot/updates_controller/translation.rb
@@ -14,7 +14,11 @@ module Telegram
           # Class-level helper for lazy translations.
           def translate(key, options = {})
             key = "#{controller_path.tr('/', '.')}#{key}" if key.to_s.start_with?('.')
-            I18n.translate(key, **options)
+            if options.empty?
+              I18n.translate(key)
+            else
+              I18n.translate(key, **options)
+            end
           end
           alias :t :translate
         end
@@ -28,7 +32,11 @@ module Telegram
             options[:default] = defaults.flatten
             key = "#{path}.#{action_name_i18n_key}#{key}"
           end
-          I18n.translate(key, **options)
+          if options.empty?
+            I18n.translate(key)
+          else
+            I18n.translate(key, **options)
+          end
         end
         alias :t :translate
 

--- a/lib/telegram/bot/updates_controller/translation.rb
+++ b/lib/telegram/bot/updates_controller/translation.rb
@@ -14,7 +14,7 @@ module Telegram
           # Class-level helper for lazy translations.
           def translate(key, options = {})
             key = "#{controller_path.tr('/', '.')}#{key}" if key.to_s.start_with?('.')
-            I18n.translate(key, options)
+            I18n.translate(key, **options)
           end
           alias :t :translate
         end
@@ -28,7 +28,7 @@ module Telegram
             options[:default] = defaults.flatten
             key = "#{path}.#{action_name_i18n_key}#{key}"
           end
-          I18n.translate(key, options)
+          I18n.translate(key, **options)
         end
         alias :t :translate
 

--- a/spec/telegram/bot/updates_controller/translation_spec.rb
+++ b/spec/telegram/bot/updates_controller/translation_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Telegram::Bot::UpdatesController::Translation do
       end
 
       it 'uses controller_path for lazy translations' do
-        expect(I18n).to receive(:translate).with('telegram.webhooks.hello', {})
+        expect(I18n).to receive(:translate).with('telegram.webhooks.hello')
         controller_class.t('.hello')
       end
     end


### PR DESCRIPTION
otherwise you encounter:
```
wrong number of arguments (given 2, expected 0..1)
/home/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/i18n-1.8.7/lib/i18n.rb:195:in `translate'
/home/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/telegram-bot-0.15.2/lib/telegram/bot/updates_controller/translation.rb:31:in `translate'
/home/project/app/controllers/telegram_webhooks_controller.rb:31:in `help!'
```