### PR TITLE
Treat callback_query_id as string in spec helper

### DIFF
--- a/lib/telegram/bot/rspec/callback_query_helpers.rb
+++ b/lib/telegram/bot/rspec/callback_query_helpers.rb
@@ -9,7 +9,7 @@ RSpec.shared_context 'telegram/bot/callback_query' do
 
   subject { -> { dispatch callback_query: payload } }
   let(:payload) { {id: callback_query_id, from: from, message: message, data: data} }
-  let(:callback_query_id) { 11 }
+  let(:callback_query_id) { '11' }
   let(:message_id) { 22 }
   let(:message) { {message_id: message_id, chat: chat, text: 'message text'} }
   let(:data) { raise '`let(:data) { "callback query data here" }` is required' }


### PR DESCRIPTION
Hey there,
I found this issue when I have TypedUpdate and callback_query.

In specs:
```
context 'callback query', :callback_query do
  let(:data) { 1 }

  it { should answer_callback_query 'response', show_alert: true }
end
I had the following error:

Failure/Error: it { should answer_callback_query 'response', show_alert: true }
       expected to make exactly 1 #<Telegram::Bot::ClientStub#...>.answerCallbackQuery requests, with [#<RSpec::Mocks::ArgumentMatchers::HashIncludingMatcher:... @expected={:show_alert=>true, :callback_query_id=>11, :text=>"response"}>], but made 0, and 1 with {:show_alert=>true, :callback_query_id=>"11", :text=>"response"}
```
spec helpers expecting callback_query_id as Integer, while app returns string.

This PR fixes it, but I can make additional changes (if needed)

Previously I made a PR to telegram-bot-types https://github.com/telegram-bot-rb/telegram-bot-types/pull/7, but maintainer told me that while API expects String, we have to fix spec helpers, not types.